### PR TITLE
run `generateIcons` at startup if sprite.svg does not exist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,22 @@ export const iconsSpritesheet: (args: PluginProps) => Plugin = ({ withTypes, inp
   apply(config) {
     return config.mode === "development";
   },
+  async configResolved(config) {
+    const outputSvgPath = normalizePath(path.join(cwd ?? process.cwd(), outputDir, fileName ?? "sprite.svg"));
+    if (
+      !(await fs
+        .access(outputSvgPath, fs.constants.F_OK)
+        .then(() => true)
+        .catch(() => false))
+    ) {
+      await generateIcons({
+        withTypes,
+        inputDir,
+        outputDir,
+        fileName,
+      });
+    }
+  },
   async watchChange(file, type) {
     const inputPath = normalizePath(path.join(cwd ?? process.cwd(), inputDir));
     if (file.includes(inputPath) && file.endsWith(".svg") && ["create", "delete"].includes(type.event)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,12 +143,11 @@ export const iconsSpritesheet: (args: PluginProps) => Plugin = ({ withTypes, inp
   },
   async configResolved(config) {
     const outputSvgPath = normalizePath(path.join(cwd ?? process.cwd(), outputDir, fileName ?? "sprite.svg"));
-    if (
-      !(await fs
-        .access(outputSvgPath, fs.constants.F_OK)
-        .then(() => true)
-        .catch(() => false))
-    ) {
+    const outputSvgExists = await fs
+      .access(outputSvgPath, fs.constants.F_OK)
+      .then(() => true)
+      .catch(() => false);
+    if (!outputSvgExists) {
       await generateIcons({
         withTypes,
         inputDir,


### PR DESCRIPTION
Fixes #2

# Description

I noticed that the plugin wasn't running at startup for already existing files because it only watches for changes in the ﻿`inputDir` directory. To address this issue, I ensured that the ﻿`generateIcons` function runs at Vite startup if the sprite.svg file does not exist. This way, the sprite.svg file will be generated at the beginning if it is missing.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):
