### PR TITLE
Configurable TS types output location

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ export default {
       inputDir: "icons",
       // Output path for the generated spritesheet and types
       outputDir: "public/icons",
+      // Output path for the generated type file, defaults to types.ts in outputDir
+      typesOutputFile: "app/icons.ts",
       // The name of the generated spritesheet, defaults to sprite.svg
       fileName: "icon.svg",
       // The cwd, defaults to process.cwd()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-icons-spritesheet",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-icons-spritesheet",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "ISC",
       "workspaces": [
         ".",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ interface PluginProps {
   withTypes?: boolean;
   inputDir: string;
   outputDir: string;
-  typesOutputDir?: string;
+  typesOutputFile?: string;
   fileName?: string;
   cwd?: string;
   iconNameTransformer?: (fileName: string) => string;
@@ -22,7 +22,7 @@ const generateIcons = async ({
   withTypes = false,
   inputDir,
   outputDir,
-  typesOutputDir = outputDir,
+  typesOutputFile = `${outputDir}/types.ts`,
   cwd,
   fileName = "sprite.svg",
   iconNameTransformer,
@@ -30,7 +30,6 @@ const generateIcons = async ({
   const cwdToUse = cwd ?? process.cwd();
   const inputDirRelative = path.relative(cwdToUse, inputDir);
   const outputDirRelative = path.relative(cwdToUse, outputDir);
-  const typesOutputDirRelative = path.relative(cwdToUse, typesOutputDir);
 
   const files = glob.sync("**/*.svg", {
     cwd: inputDir,
@@ -50,10 +49,14 @@ const generateIcons = async ({
   });
 
   if (withTypes) {
+    const typesOutputDir = path.dirname(typesOutputFile);
+    const typesFile = path.basename(typesOutputFile);
+    const typesOutputDirRelative = path.relative(cwdToUse, typesOutputDir);
+
     await mkdir(typesOutputDirRelative, { recursive: true });
     await generateTypes({
       names: files.map((file: string) => transformIconName(file, iconNameTransformer ?? fileNameToCamelCase)),
-      outputPath: path.join(typesOutputDir, "types.ts"),
+      outputPath: path.join(typesOutputDir, typesFile),
     });
   }
 };
@@ -161,7 +164,7 @@ export const iconsSpritesheet: (args: PluginProps) => Plugin = ({
   withTypes,
   inputDir,
   outputDir,
-  typesOutputDir,
+  typesOutputFile,
   fileName,
   cwd,
   iconNameTransformer,
@@ -171,7 +174,7 @@ export const iconsSpritesheet: (args: PluginProps) => Plugin = ({
       withTypes,
       inputDir,
       outputDir,
-      typesOutputDir,
+      typesOutputFile,
       fileName,
       iconNameTransformer,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,7 @@ export const iconsSpritesheet: (args: PluginProps) => Plugin = ({
   withTypes,
   inputDir,
   outputDir,
+  typesOutputDir,
   fileName,
   cwd,
   iconNameTransformer,
@@ -170,6 +171,7 @@ export const iconsSpritesheet: (args: PluginProps) => Plugin = ({
       withTypes,
       inputDir,
       outputDir,
+      typesOutputDir,
       fileName,
       iconNameTransformer,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ interface PluginProps {
   withTypes?: boolean;
   inputDir: string;
   outputDir: string;
+  typesOutputDir?: string;
   fileName?: string;
   cwd?: string;
   iconNameTransformer?: (fileName: string) => string;
@@ -21,6 +22,7 @@ const generateIcons = async ({
   withTypes = false,
   inputDir,
   outputDir,
+  typesOutputDir = outputDir,
   cwd,
   fileName = "sprite.svg",
   iconNameTransformer,
@@ -28,6 +30,7 @@ const generateIcons = async ({
   const cwdToUse = cwd ?? process.cwd();
   const inputDirRelative = path.relative(cwdToUse, inputDir);
   const outputDirRelative = path.relative(cwdToUse, outputDir);
+  const typesOutputDirRelative = path.relative(cwdToUse, typesOutputDir);
 
   const files = glob.sync("**/*.svg", {
     cwd: inputDir,
@@ -45,10 +48,12 @@ const generateIcons = async ({
     outputDirRelative,
     iconNameTransformer,
   });
+
   if (withTypes) {
+    await mkdir(typesOutputDirRelative, { recursive: true });
     await generateTypes({
       names: files.map((file: string) => transformIconName(file, iconNameTransformer ?? fileNameToCamelCase)),
-      outputPath: path.join(outputDir, "types.ts"),
+      outputPath: path.join(typesOutputDir, "types.ts"),
     });
   }
 };


### PR DESCRIPTION
Fixes #8

# Description

Introduced `typesOutputFile` to control where to output the generated types file.
Defaults to `${outputDir}/types.ts`

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [x] Check if the code is well documented
- [x] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [x] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):
