### PR TITLE
Don't minify built output

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "test": "vitest run",
     "test:cov": "vitest run --coverage",
-    "build": "tsup src/index.ts  --dts --format esm,cjs --outDir dist --minify --clean",
+    "build": "tsup src/index.ts  --dts --format esm,cjs --outDir dist --clean",
     "remix:dev": "npm run dev -w test-apps/remix-vite",
     "remix:cjs:dev": "npm run dev -w test-apps/remix-vite-cjs",
     "build:dev": "tsup src/index.ts --dts --format cjs,esm  --outDir dist",


### PR DESCRIPTION
Fixes debugging of the published package.

# Description

While attempting to debug the recent "Ignore the assetSizeLimit for spritesheets" feature failing, I was met with minified output which made debugging quite cumbersome. 😩 Nobody is worried about a few bytes saved in a Vite plugin, so let's not do that. 🙂 

https://x.com/kentcdodds/status/1394420201542668289

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests
- [x] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [ ] Check if the code is well documented
- [x] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):
