### PR TITLE
Fix spritesheet path matching when ignoring assetsInlineLimit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -337,7 +337,7 @@ export const iconsSpritesheet: (args: PluginProps | PluginProps[]) => any = (may
 
           config.build.assetsInlineLimit = (name, content) => {
             const isSpriteSheet = allSpriteSheetNames.some((spriteSheetName) => {
-              return name === normalizePath(`${workDir}/${outputDir}/${spriteSheetName}`);
+              return name === normalizePath(`${outputDir}/${spriteSheetName}`);
             });
             // Our spritesheet? Early return
             if (isSpriteSheet) {


### PR DESCRIPTION
Fixes #22

# Description

Changes the path for matching "our spritesheet" from `workDir/outputDir/spriteSheetName` to `outputDir/spriteSheetName`. Tested manually on Windows and macOS.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [ ] Check if the code is well documented
- [x] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):
