### PR TITLE
Support missing Vite build config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -310,9 +310,12 @@ export const iconsSpritesheet: (args: PluginProps | PluginProps[]) => any = (may
         }
       },
       async config(config) {
-        if (!config.build || i > 0) {
+        if (i > 0) {
           return;
         }
+
+        config.build = config.build ?? {};
+
         const subFunc =
           typeof config.build.assetsInlineLimit === "function" ? config.build.assetsInlineLimit : undefined;
         const limit = typeof config.build.assetsInlineLimit === "number" ? config.build.assetsInlineLimit : undefined;


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/12947

# Description

This plugin assumes that `config.build` exists and bails out if it's not there, but this causes issues with React Router's Vite plugin because the build config is only defined when running a production build.

To fix this, we now ensure that `config.build` exists, defining it as an empty object if it's not there, before proceeding with the rest of the plugin logic. This is so we don't need to constantly guard against a missing build config object and keep the rest of the logic clean.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

I manually tested against this repro by modifying node_modules: https://stackblitz.com/~/github.com/AlemTuzlak/asset-inline-limit-repro

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
