### PR TITLE
Sort SVG files in a case-insensitive manner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,8 @@ const generateIcons = async ({
 
   const files = glob.sync("**/*.svg", {
     cwd: inputDir,
-  });
+  }).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+  
   if (files.length === 0) {
     console.log(`⚠️  No SVG files found in ${chalk.red(inputDirRelative)}`);
     return;


### PR DESCRIPTION
Fixes #41 

Always changes that are annoying between mac and windows. This should fix this